### PR TITLE
Rd/add contract generator

### DIFF
--- a/src/ConcordNet.UnitTests/GeneratorTests.cs
+++ b/src/ConcordNet.UnitTests/GeneratorTests.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using ConcordNet.Models;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace ConcordNet.UnitTests
+{
+    public class GeneratorTests
+    {
+        [Test]
+        public void GeneratorWritesValues()
+        {
+            var config = new ConcordGeneratorConfig()
+            {
+                ContractDirectory = "C:/temp/pacts2"
+            };
+            var gen = new ConcordGenerator(config);
+            gen.ServiceConsumer("consumer1").HasPactWith("provider1");
+            gen.MockService(4099);
+            gen.Generate();
+
+            var lines = File.ReadAllText("C:/temp/pacts2/consumer1-provider1.json");
+            var obj = JsonConvert.DeserializeObject<List<Contract>>(lines);
+            Assert.That(obj.GetType() == typeof(List<Contract>));
+        }
+    }
+}

--- a/src/ConcordNet.UnitTests/MockProviderTests.cs
+++ b/src/ConcordNet.UnitTests/MockProviderTests.cs
@@ -1,0 +1,20 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ConcordNet.UnitTests
+{
+    public class MockProviderTests
+    {
+        [Test]
+        public async Task GivenAPort_MockProviderHosts()
+        {
+            int port = 4025;
+            var mockProvider = new MockProviderService(port);
+            HttpClient client = new HttpClient();
+            var response = await client.GetAsync($"http://localhost:{port}/");
+            Assert.That(response.StatusCode == HttpStatusCode.Found);
+        }
+    }
+}

--- a/src/ConcordNet.UnitTests/MockProviderTests.cs
+++ b/src/ConcordNet.UnitTests/MockProviderTests.cs
@@ -1,20 +1,85 @@
-﻿using System.Net;
+﻿using System;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using ConcordNet.Models;
 using NUnit.Framework;
 
 namespace ConcordNet.UnitTests
 {
     public class MockProviderTests
     {
+        private int port = 4025;
+
         [Test]
         public async Task GivenAPort_MockProviderHosts()
         {
-            int port = 4025;
             var mockProvider = new MockProviderService(port);
             HttpClient client = new HttpClient();
             var response = await client.GetAsync($"http://localhost:{port}/");
-            Assert.That(response.StatusCode == HttpStatusCode.Found);
+            Assert.That(response.StatusCode == HttpStatusCode.NotFound);
+        }
+
+        [Test]
+        public void GivenAContractToBuild_ItIsInTheStore()
+        {
+            var mockProvider = new MockProviderService(port);
+            mockProvider.Given("A Test").UponReceiving("A Request").With(new ContractRequest()
+            {
+                Method = "Get",
+                Url = "/1234"
+            }).WillRespondWith(new ContractResponse()
+            {
+                StatusCode = HttpStatusCode.OK
+            });
+            var contractFromStore = mockProvider.GetContracts().FirstOrDefault(c => c.Name == "A Test");
+            Assert.NotNull(contractFromStore);
+            Assert.AreEqual("A Test", contractFromStore.Name);
+            Assert.AreEqual("A Request", contractFromStore.Scenario);
+            Assert.AreEqual("Get", contractFromStore.Request.Method);
+            Assert.AreEqual("/1234", contractFromStore.Request.Url);
+            Assert.AreEqual(HttpStatusCode.OK, contractFromStore.Response.StatusCode);
+        }
+
+        [Test]
+        public void GivenAPartialContract_AndAttemptToStartAnother_ItThrowsException()
+        {
+            var mockProvider = new MockProviderService(port);
+            mockProvider.Given("Test1");
+
+            Assert.Throws<Exception>(() => mockProvider.Given("Test2"));
+
+            mockProvider.UponReceiving("A Request");
+
+            Assert.Throws<Exception>(() => mockProvider.Given("A Request 2"));
+        }
+
+        [Test]
+        public void GivenAContractWithoutRequest_AndAttemptToComplete_ItThrowsException()
+        {
+            var mockProvider = new MockProviderService(port);
+            mockProvider.Given("A Test");
+
+
+            Assert.Throws<Exception>(() =>
+                mockProvider.WillRespondWith(new ContractResponse() {StatusCode = HttpStatusCode.Accepted}));
+        }
+
+        [Test]
+        public async Task GivenAContract_AndItsRequested_TheProviderReturnsTheResponse()
+        {
+            var mockProvider = new MockProviderService(port);
+            mockProvider.Given("A Test").UponReceiving("A Scenario").With(new ContractRequest(){Url = "/1234",Method = "GET"}).WillRespondWith(new ContractResponse()
+            {
+                StatusCode = HttpStatusCode.OK
+            });
+            
+            HttpClient client = new HttpClient();
+            var response = await client.GetAsync($"http://localhost:{port}/1234");
+            Assert.That(response.StatusCode == HttpStatusCode.OK);
+            
+            
         }
     }
 }

--- a/src/ConcordNet.sln
+++ b/src/ConcordNet.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleApi.ConcordTests", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsumerApi", "ConsumerApi\ConsumerApi.csproj", "{204DD650-7801-4813-9942-6AE32EAD99E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsumerApi.ConcordTests", "ConsumerApi.ConcordTests\ConsumerApi.ConcordTests.csproj", "{80477E8F-099E-48CF-939F-7B446C97985E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,5 +38,9 @@ Global
 		{204DD650-7801-4813-9942-6AE32EAD99E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{204DD650-7801-4813-9942-6AE32EAD99E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{204DD650-7801-4813-9942-6AE32EAD99E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80477E8F-099E-48CF-939F-7B446C97985E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80477E8F-099E-48CF-939F-7B446C97985E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80477E8F-099E-48CF-939F-7B446C97985E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80477E8F-099E-48CF-939F-7B446C97985E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/ConcordNet.sln
+++ b/src/ConcordNet.sln
@@ -8,6 +8,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleApi", "ExampleApi\Ex
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleApi.ConcordTests", "ExampleApi.ConcordTests\ExampleApi.ConcordTests.csproj", "{6F202010-9A9A-438D-A6D9-562C3CEE0F3B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsumerApi", "ConsumerApi\ConsumerApi.csproj", "{204DD650-7801-4813-9942-6AE32EAD99E2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{6F202010-9A9A-438D-A6D9-562C3CEE0F3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6F202010-9A9A-438D-A6D9-562C3CEE0F3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6F202010-9A9A-438D-A6D9-562C3CEE0F3B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{204DD650-7801-4813-9942-6AE32EAD99E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{204DD650-7801-4813-9942-6AE32EAD99E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{204DD650-7801-4813-9942-6AE32EAD99E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{204DD650-7801-4813-9942-6AE32EAD99E2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/ConcordNet/ConcordGenerator.cs
+++ b/src/ConcordNet/ConcordGenerator.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.IO;
+using System.Text.Json;
+using ConcordNet.Interfaces;
+
+namespace ConcordNet
+{
+    public class ConcordGeneratorConfig
+    {
+        public string ContractDirectory { get; set; }
+    }
+    public class ConcordGenerator : IConcordGenerator
+    {
+        private string contractDirectory;
+        
+        private string Consumer;
+        private string Provider;
+        
+        private IMockProviderService _providerService;
+
+
+        public ConcordGenerator(ConcordGeneratorConfig config)
+        {
+            contractDirectory = config.ContractDirectory;
+            if (!contractDirectory.EndsWith("/"))
+            {
+                contractDirectory += "/";
+            }
+
+            if (!Directory.Exists(contractDirectory))
+            {
+                Directory.CreateDirectory(contractDirectory);
+            }
+        }
+        public IMockProviderService MockService(int port)
+        {
+            _providerService = new MockProviderService(port);
+            return _providerService;
+        }
+
+        public IConcordGenerator ServiceConsumer(string ServiceConsumer)
+        {
+            Consumer = ServiceConsumer;
+            return this;
+        }
+
+        public IConcordGenerator HasContractWith(string providerService)
+        {
+            Provider = providerService;
+            return this;
+        }
+
+        [Obsolete]
+        public IConcordGenerator HasPactWith(string providerService)
+        {
+            Provider = providerService;
+            return this;
+        }
+
+        public void Generate()
+        {
+            if (_providerService == null)
+            {
+                throw new Exception("Mock the provider service");
+            }
+
+            if (string.IsNullOrEmpty(Consumer))
+            {
+                throw new Exception("Define the service");
+            }
+
+            if (string.IsNullOrEmpty(Provider))
+            {
+                throw new Exception("Define the provider");
+            }
+
+            var contracts = _providerService.GetContracts();
+            File.WriteAllText($"{contractDirectory}{Consumer}-{Provider}.json", JsonSerializer.Serialize(contracts));
+        }
+    }
+}

--- a/src/ConcordNet/Interfaces/IConcordGenerator.cs
+++ b/src/ConcordNet/Interfaces/IConcordGenerator.cs
@@ -1,0 +1,11 @@
+﻿namespace ConcordNet.Interfaces
+{
+    public interface IConcordGenerator
+    {
+        public IMockProviderService MockService(int port);
+
+        public IConcordGenerator ServiceConsumer(string serviceConsumer);
+        public IConcordGenerator HasPactWith(string providerService);
+        public void Generate();
+    }
+}

--- a/src/ConcordNet/Interfaces/IMockProviderService.cs
+++ b/src/ConcordNet/Interfaces/IMockProviderService.cs
@@ -5,6 +5,14 @@ namespace ConcordNet.Interfaces
 {
     public interface IMockProviderService
     {
+        public string BaseAddress { get;  }
         public IEnumerable<Contract> GetContracts();
+
+        public IMockProviderService Given(string name);
+        public IMockProviderService UponReceiving(string scenario);
+
+        public IMockProviderService With(ContractRequest request);
+
+        public void WillRespondWith(ContractResponse response);
     }
 }

--- a/src/ConcordNet/Interfaces/IMockProviderService.cs
+++ b/src/ConcordNet/Interfaces/IMockProviderService.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using ConcordNet.Models;
+
+namespace ConcordNet.Interfaces
+{
+    public interface IMockProviderService
+    {
+        public IEnumerable<Contract> GetContracts();
+    }
+}

--- a/src/ConcordNet/MockProviderService.cs
+++ b/src/ConcordNet/MockProviderService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Net;
-using System.Threading;
+using System.Linq;
 using System.Threading.Tasks;
 using ConcordNet.Interfaces;
 using ConcordNet.Models;
@@ -9,15 +8,20 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
+using Newtonsoft.Json;
+using Contract = ConcordNet.Models.Contract;
 
 namespace ConcordNet
 {
-    public class MockProviderService : IDisposable,IMockProviderService
+    public class MockProviderService : IDisposable, IMockProviderService
     {
         private readonly IHost _host;
         public int Port = 4001;
-        public string BaseUrl => $"http://localhost:{Port}/";
-        private IEnumerable<Contract> contracts;
+        public string BaseAddress => $"http://localhost:{Port}/";
+        
+        private IList<Contract> contracts;
+
+        private Contract buildingContract;
 
         public MockProviderService(int port)
         {
@@ -25,21 +29,62 @@ namespace ConcordNet
 
             _host = Host.CreateDefaultBuilder().ConfigureWebHostDefaults(webBuilder =>
             {
-                webBuilder.UseUrls(BaseUrl);
+                webBuilder.UseUrls(BaseAddress);
                 webBuilder.Configure((WebHostBuilderContext context, IApplicationBuilder app) =>
                 {
                     app.UseRouting();
-                    app.UseEndpoints(endpoints =>
-                    {
-                        endpoints.Map("/", RequestHandler);
-                    });
+                    app.UseEndpoints(endpoints => { endpoints.Map("/{**slug}", RequestHandler); });
                 });
             }).Build();
             _host.RunAsync();
-            contracts = new List<Contract>(){new Contract(){Name="NAme",Scenario = "Scenario1",Request = new ContractRequest(){Method = "GET",Url="/abcd"},Response = new ContractResponse(){StatusCode = HttpStatusCode.OK}}};
+            buildingContract = new Contract();
+            contracts = new List<Contract>();
         }
 
-        
+        public IMockProviderService Given(string name)
+        {
+            if (!string.IsNullOrEmpty(buildingContract.Name))
+            {
+                throw new Exception($"Finish contract with WillRespondWith on {buildingContract.Name}");
+            }
+
+            buildingContract.Name = name;
+            return this;
+        }
+
+        public IMockProviderService UponReceiving(string scenario)
+        {
+            if (!string.IsNullOrEmpty(buildingContract.Scenario))
+            {
+                throw new Exception($"Finish contract with WillRespondWith on {buildingContract.Scenario}");
+            }
+
+            buildingContract.Scenario = scenario;
+            return this;
+        }
+
+        public IMockProviderService With(ContractRequest request)
+        {
+            if (buildingContract.Request != null)
+            {
+                throw new Exception($"Finish contract with WillRespondWith on {buildingContract.Request.Url}");
+            }
+
+            buildingContract.Request = request;
+            return this;
+        }
+
+        public void WillRespondWith(ContractResponse response)
+        {
+            if (buildingContract.Request == null)
+            {
+                throw new Exception("Request not defined for response");
+            }
+            buildingContract.Response = response;
+            contracts.Add(buildingContract);
+            buildingContract = new Contract();
+        }
+
 
         private async Task RequestHandler(HttpContext context)
         {
@@ -49,11 +94,34 @@ namespace ConcordNet
                 context.Response.StatusCode = 404;
                 await context.Response.CompleteAsync();
             }
+            else
+            {
+                context.Response.StatusCode = (int) contract.Response.StatusCode;
+                
+                if (contract.Response.Headers != null)
+                {
+                    foreach (var header in contract.Response.Headers)
+                    {
+                        context.Response.Headers.Add(header.Key, header.Value);
+                    }
+                }
+
+                if (contract.Response.Body == null)
+                {
+                    await context.Response.CompleteAsync();
+                }
+                await context.Response.WriteAsync(JsonConvert.SerializeObject(contract.Response.Body));
+            }
         }
-        
+
         private Contract FindContract(HttpContext context)
         {
-            return null;
+            return contracts.FirstOrDefault(c => ContractMatches(c.Request, context.Request));
+        }
+
+        private bool ContractMatches(ContractRequest contract, HttpRequest request)
+        {
+            return contract.Method == request.Method && contract.Url == request.Path;
         }
 
         public void Dispose()

--- a/src/ConcordNet/MockProviderService.cs
+++ b/src/ConcordNet/MockProviderService.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using ConcordNet.Interfaces;
+using ConcordNet.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+
+namespace ConcordNet
+{
+    public class MockProviderService : IDisposable,IMockProviderService
+    {
+        private readonly IHost _host;
+        public int Port = 4001;
+        public string BaseUrl => $"http://localhost:{Port}/";
+        private IEnumerable<Contract> contracts;
+
+        public MockProviderService(int port)
+        {
+            Port = port;
+
+            _host = Host.CreateDefaultBuilder().ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseUrls(BaseUrl);
+                webBuilder.Configure((WebHostBuilderContext context, IApplicationBuilder app) =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.Map("/", RequestHandler);
+                    });
+                });
+            }).Build();
+            _host.RunAsync();
+            contracts = new List<Contract>(){new Contract(){Name="NAme",Scenario = "Scenario1",Request = new ContractRequest(){Method = "GET",Url="/abcd"},Response = new ContractResponse(){StatusCode = HttpStatusCode.OK}}};
+        }
+
+        
+
+        private async Task RequestHandler(HttpContext context)
+        {
+            var contract = FindContract(context);
+            if (contract == null)
+            {
+                context.Response.StatusCode = 404;
+                await context.Response.CompleteAsync();
+            }
+        }
+        
+        private Contract FindContract(HttpContext context)
+        {
+            return null;
+        }
+
+        public void Dispose()
+        {
+            _host.StopAsync().GetAwaiter().GetResult();
+        }
+
+        public IEnumerable<Contract> GetContracts()
+        {
+            return contracts;
+        }
+    }
+}

--- a/src/ConcordNet/Models/ContractResponse.cs
+++ b/src/ConcordNet/Models/ContractResponse.cs
@@ -11,7 +11,7 @@ namespace ConcordNet.Models
         public HttpStatusCode StatusCode { get; set; }
         
         [JsonProperty("headers")]
-        public IEnumerable<string> Headers { get; set; }
+        public Dictionary<string,string> Headers { get; set; }
         
         [JsonProperty("body")]
         public object Body { get; set; }

--- a/src/ConsumerApi.ConcordTests/ConsumerApi.ConcordTests.csproj
+++ b/src/ConsumerApi.ConcordTests/ConsumerApi.ConcordTests.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Moq" Version="4.14.1" />
         <PackageReference Include="nunit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
@@ -14,6 +15,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\ConcordNet\ConcordNet.csproj" />
+      <ProjectReference Include="..\ConsumerApi\ConsumerApi.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/ConsumerApi.ConcordTests/ConsumerApi.ConcordTests.csproj
+++ b/src/ConsumerApi.ConcordTests/ConsumerApi.ConcordTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="nunit" Version="3.12.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\ConcordNet\ConcordNet.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/ConsumerApi.ConcordTests/ConsumerTests/ExampleApiFixture.cs
+++ b/src/ConsumerApi.ConcordTests/ConsumerTests/ExampleApiFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Dynamic;
+using ConcordNet;
 using ConcordNet.Interfaces;
 
 namespace ConsumerApi.ConcordTests.ConsumerTests
@@ -14,6 +15,9 @@ namespace ConsumerApi.ConcordTests.ConsumerTests
 
         public ExampleApiFixture()
         {
+            var config = new ConcordGeneratorConfig {ContractDirectory = "C:/temp/pacts"};
+            ConcordGenerator = new ConcordGenerator(config);
+            ConcordGenerator.ServiceConsumer("ConsumerApi").HasPactWith("ExampleApi");
             MockProviderService = ConcordGenerator.MockService(port);
         }
         

--- a/src/ConsumerApi.ConcordTests/ConsumerTests/ExampleApiFixture.cs
+++ b/src/ConsumerApi.ConcordTests/ConsumerTests/ExampleApiFixture.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Dynamic;
+using ConcordNet.Interfaces;
+
+namespace ConsumerApi.ConcordTests.ConsumerTests
+{
+    public class ExampleApiFixture : IDisposable
+    {
+        private IConcordGenerator ConcordGenerator { get; }
+        
+        public IMockProviderService MockProviderService { get; }
+
+        private int port = 4035;
+
+        public ExampleApiFixture()
+        {
+            MockProviderService = ConcordGenerator.MockService(port);
+        }
+        
+        public void Dispose()
+        {
+            ConcordGenerator.Generate();
+        }
+    }
+}

--- a/src/ConsumerApi.ConcordTests/ConsumerTests/ExampleApiTests.cs
+++ b/src/ConsumerApi.ConcordTests/ConsumerTests/ExampleApiTests.cs
@@ -1,0 +1,24 @@
+﻿using ConcordNet.Interfaces;
+using NUnit.Framework;
+
+namespace ConsumerApi.ConcordTests.ConsumerTests
+{
+    [TestFixture]
+    public class ExampleApiTests
+    {
+        private IMockProviderService _mockProviderService;
+        private ExampleApiFixture _fixture;
+        [OneTimeSetUp]
+        public void Init()
+        {
+            _fixture = new ExampleApiFixture();
+            _mockProviderService = _fixture.MockProviderService;
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            _fixture.Dispose();
+        }
+    }
+}

--- a/src/ConsumerApi.ConcordTests/ConsumerTests/ExampleApiTests.cs
+++ b/src/ConsumerApi.ConcordTests/ConsumerTests/ExampleApiTests.cs
@@ -1,4 +1,14 @@
-﻿using ConcordNet.Interfaces;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using ConcordNet.Interfaces;
+using ConcordNet.Models;
+using ConsumerApi.Clients;
+using ConsumerApi.Clients.Model;
+using Moq;
 using NUnit.Framework;
 
 namespace ConsumerApi.ConcordTests.ConsumerTests
@@ -8,11 +18,37 @@ namespace ConsumerApi.ConcordTests.ConsumerTests
     {
         private IMockProviderService _mockProviderService;
         private ExampleApiFixture _fixture;
+        private IHttpClientFactory _factory;
         [OneTimeSetUp]
         public void Init()
         {
             _fixture = new ExampleApiFixture();
             _mockProviderService = _fixture.MockProviderService;
+            var factory = new Mock<IHttpClientFactory>();
+            factory.Setup(c => c.CreateClient("ExampleApi")).Returns(new HttpClient()
+                {BaseAddress = new Uri(_mockProviderService.BaseAddress)});
+            _factory = factory.Object;
+
+        }
+
+        [Test]
+        public async  Task DoSomethingWithAClient()
+        {
+            _mockProviderService.Given("A Test").UponReceiving("Some State").With(new ContractRequest()
+            {
+                Url = "/data",
+                Method = "GET"
+            }).WillRespondWith(new ContractResponse()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Body = new List<ExampleData>{new ExampleData{Color="blue",Id="5"}}
+            });
+            var client = new ExampleClient(_factory);
+            var response = await client.GetSomethingFromApi();
+            Assert.That(response.Count() == 1);
+            Assert.That(response.First().Color == "blue");
+            
+            
         }
 
         [OneTimeTearDown]

--- a/src/ConsumerApi/Clients/ExampleClient.cs
+++ b/src/ConsumerApi/Clients/ExampleClient.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using ConsumerApi.Clients.Interface;
+using ConsumerApi.Clients.Model;
+
+namespace ConsumerApi.Clients
+{
+    public class ExampleClient : IExampleClient
+    {
+        private readonly HttpClient _exampleClient;
+        
+        public ExampleClient(IHttpClientFactory clientFactory)
+        {
+            _exampleClient = clientFactory.CreateClient("ExampleApi");
+        }
+
+        public async Task<IEnumerable<ExampleData>> GetSomethingFromApi()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "/data");
+
+
+            var response = await _exampleClient.SendAsync(request);
+            var responseMessage = await response.Content.ReadAsStringAsync();
+            if (response.IsSuccessStatusCode)
+            {
+                return JsonSerializer.Deserialize<IEnumerable<ExampleData>>(responseMessage);
+            }
+            throw new Exception(responseMessage);
+        }
+    }
+}

--- a/src/ConsumerApi/Clients/Interface/IExampleClient.cs
+++ b/src/ConsumerApi/Clients/Interface/IExampleClient.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using ConsumerApi.Clients.Model;
+
+namespace ConsumerApi.Clients.Interface
+{
+    public interface IExampleClient
+    {
+        public Task<IEnumerable<ExampleData>> GetSomethingFromApi();
+    }
+}

--- a/src/ConsumerApi/Clients/Model/ExampleData.cs
+++ b/src/ConsumerApi/Clients/Model/ExampleData.cs
@@ -4,10 +4,8 @@ namespace ConsumerApi.Clients.Model
 {
     public class ExampleData
     {
-        [JsonPropertyName("id")]
         public string Id { get; set; }
         
-        [JsonPropertyName("color")]
         public string Color { get; set; }
     }
 }

--- a/src/ConsumerApi/Clients/Model/ExampleData.cs
+++ b/src/ConsumerApi/Clients/Model/ExampleData.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ConsumerApi.Clients.Model
+{
+    public class ExampleData
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+        
+        [JsonPropertyName("color")]
+        public string Color { get; set; }
+    }
+}

--- a/src/ConsumerApi/ConsumerApi.csproj
+++ b/src/ConsumerApi/ConsumerApi.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+
+</Project>

--- a/src/ConsumerApi/Controllers/ExampleController.cs
+++ b/src/ConsumerApi/Controllers/ExampleController.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using ConsumerApi.Clients.Interface;
+using ConsumerApi.Clients.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ConsumerApi.Controllers
+{
+    [Route("[controller]")]
+    [ApiController]
+    public class ExampleController :ControllerBase
+    {
+        private readonly IExampleClient _client;
+
+        public ExampleController(IExampleClient client)
+        {
+            _client = client;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Get()
+        {
+            return Ok(await _client.GetSomethingFromApi());
+        }
+    }
+}

--- a/src/ConsumerApi/Program.cs
+++ b/src/ConsumerApi/Program.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace ConsumerApi
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
+    }
+}

--- a/src/ConsumerApi/Properties/launchSettings.json
+++ b/src/ConsumerApi/Properties/launchSettings.json
@@ -1,0 +1,30 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:39120",
+      "sslPort": 44358
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "example",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "ConsumerApi": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "example",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/ConsumerApi/Startup.cs
+++ b/src/ConsumerApi/Startup.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ConsumerApi.Clients;
+using ConsumerApi.Clients.Interface;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace ConsumerApi
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+            services.AddSingleton<IExampleClient, ExampleClient>();
+            services.AddHttpClient("ExampleApi", client =>
+            {
+                client.BaseAddress = new Uri("http://localhost:28826");
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
+        }
+    }
+}

--- a/src/ConsumerApi/appsettings.Development.json
+++ b/src/ConsumerApi/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/src/ConsumerApi/appsettings.json
+++ b/src/ConsumerApi/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Added in contract generator class which acts like Pact Builder
Currently generates contracts for all registered requests in the mock provider service when cleaning up
included ConsumerApi sample (with sample tests)